### PR TITLE
Use generic CMDB deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,13 @@ def tryStep(String message, Closure block, Closure tearDown = null) {
     }
 }
 
+def retagAndPush(String imageName, String currentTag, String newTag)
+{
+    def regex = ~"^https?://"
+    def dockerReg = "${DOCKER_REGISTRY_HOST}" - regex
+    sh "docker tag ${dockerReg}/${imageName}:${currentTag} ${dockerReg}/${imageName}:${newTag}"
+    sh "docker push ${dockerReg}/${imageName}:${newTag}"
+}
 
 node {
     stage("Checkout") {
@@ -49,9 +56,11 @@ if (BRANCH == "master") {
         stage('Push acceptance image') {
             tryStep "image tagging", {
                 docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
-                    def image = docker.image("mijnams/mks:${env.BUILD_NUMBER}")
-                    image.pull()
-                    image.push("acceptance")
+                    docker.image("mijnams/mks:${env.BUILD_NUMBER}").pull()
+                    // The Image.push() function ignores the docker registry prefix of the image name,
+                    // which means that we cannot re-tag an image that was built in a different stage (on a different node).
+                    // Resort to manual tagging to allow build and tag steps to run on different Jenkins slaves.
+                    retagAndPush("mijnams/wmoned", "${env.BUILD_NUMBER}", "acceptance")
                 }
             }
         }
@@ -63,7 +72,8 @@ if (BRANCH == "master") {
                 build job: 'Subtask_Openstack_Playbook',
                     parameters: [
                         [$class: 'StringParameterValue', name: 'INVENTORY', value: 'acceptance'],
-                        [$class: 'StringParameterValue', name: 'PLAYBOOK', value: 'deploy-mijn-mks.yml'],
+                        [$class: 'StringParameterValue', name: 'PLAYBOOK', value: 'deploy.yml'],
+                        [$class: 'StringParameterValue', name: 'PLAYBOOKPARAMS', value: "-e cmdb_id=app_mijn-mks"]
                     ]
             }
         }
@@ -78,10 +88,9 @@ if (BRANCH == "master") {
         stage('Push production image') {
             tryStep "image tagging", {
                 docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
-                    def image = docker.image("mijnams/mks:${env.BUILD_NUMBER}")
-                    image.pull()
-                    image.push("production")
-                    image.push("latest")
+                    docker.image("mijnams/mks:${env.BUILD_NUMBER}").pull()
+                    retagAndPush("mijnams/mks", "${env.BUILD_NUMBER}", "production")
+                    retagAndPush("mijnams/mks", "${env.BUILD_NUMBER}", "latest")
                 }
             }
         }
@@ -93,7 +102,8 @@ if (BRANCH == "master") {
                 build job: 'Subtask_Openstack_Playbook',
                     parameters: [
                         [$class: 'StringParameterValue', name: 'INVENTORY', value: 'production'],
-                        [$class: 'StringParameterValue', name: 'PLAYBOOK', value: 'deploy-mijn-mks.yml'],
+                        [$class: 'StringParameterValue', name: 'PLAYBOOK', value: 'deploy.yml'],
+                        [$class: 'StringParameterValue', name: 'PLAYBOOKPARAMS', value: "-e cmdb_id=app_mijn-mks"]
                     ]
             }
         }


### PR DESCRIPTION
Also includes support for running job stages over different build slaves.